### PR TITLE
Modifications to the schema for validation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/3DRotation/3DRotationJSONSchema.json
+++ b/3DRotation/3DRotationJSONSchema.json
@@ -254,11 +254,12 @@
       "description" : "An identifier that can be used either by the developer or researcher for custom mapping.",
       "type" : "string"
     },
+    "schemaIdentifierPath" : {
+      "description" : "URL linking to the version of the schema against which these data should validate.",
+      "type" : "string"
+    },
     "scores" : {
-      "items" : {
-        "$ref" : "#/definitions/DEScores"
-      },
-      "type" : "array"
+      "$ref" : "#/definitions/DEScores"
     },
     "seed" : {
       "type" : "integer"

--- a/3DRotation/3DRotationJSONSchema.json
+++ b/3DRotation/3DRotationJSONSchema.json
@@ -254,8 +254,12 @@
       "description" : "An identifier that can be used either by the developer or researcher for custom mapping.",
       "type" : "string"
     },
-    "schemaIdentifierPath" : {
+    "jsonSchema" : {
       "description" : "URL linking to the version of the schema against which these data should validate.",
+      "type" : "string"
+    },
+    "$schema" : {
+      "description" : "a temporary URL linking to the version of the schema used during the ICAR pilot.",
       "type" : "string"
     },
     "scores" : {

--- a/LetterNumberSeries/LetterNumberSeriesJSONSchema.json
+++ b/LetterNumberSeries/LetterNumberSeriesJSONSchema.json
@@ -204,8 +204,12 @@
       "description" : "An identifier that can be used either by the developer or researcher for custom mapping.",
       "type" : "string"
     },
-    "schemaIdentifierPath" : {
+    "jsonSchema" : {
       "description" : "URL linking to the version of the schema against which these data should validate.",
+      "type" : "string"
+    },
+    "$schema" : {
+      "description" : "a temporary URL linking to the version of the schema used during the ICAR pilot.",
       "type" : "string"
     },
     "scores" : {

--- a/LetterNumberSeries/LetterNumberSeriesJSONSchema.json
+++ b/LetterNumberSeries/LetterNumberSeriesJSONSchema.json
@@ -204,11 +204,12 @@
       "description" : "An identifier that can be used either by the developer or researcher for custom mapping.",
       "type" : "string"
     },
+    "schemaIdentifierPath" : {
+      "description" : "URL linking to the version of the schema against which these data should validate.",
+      "type" : "string"
+    },
     "scores" : {
-      "items" : {
-        "$ref" : "#/definitions/MSSRawScoreResult"
-      },
-      "type" : "array"
+      "$ref" : "#/definitions/MSSRawScoreResult"
     },
     "startDate" : {
       "format" : "date-time",

--- a/MobileToolboxSchemas.Rproj
+++ b/MobileToolboxSchemas.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX

--- a/ProgressiveMatrices/ProgressiveMatricesJSONSchema.json
+++ b/ProgressiveMatrices/ProgressiveMatricesJSONSchema.json
@@ -254,11 +254,12 @@
       "description" : "An identifier that can be used either by the developer or researcher for custom mapping.",
       "type" : "string"
     },
+    "schemaIdentifierPath" : {
+      "description" : "URL linking to the version of the schema against which these data should validate.",
+      "type" : "string"
+    },
     "scores" : {
-      "items" : {
-        "$ref" : "#/definitions/DEScores"
-      },
-      "type" : "array"
+      "$ref" : "#/definitions/DEScores"
     },
     "seed" : {
       "type" : "integer"

--- a/ProgressiveMatrices/ProgressiveMatricesJSONSchema.json
+++ b/ProgressiveMatrices/ProgressiveMatricesJSONSchema.json
@@ -254,8 +254,12 @@
       "description" : "An identifier that can be used either by the developer or researcher for custom mapping.",
       "type" : "string"
     },
-    "schemaIdentifierPath" : {
+    "jsonSchema" : {
       "description" : "URL linking to the version of the schema against which these data should validate.",
+      "type" : "string"
+    },
+    "$schema" : {
+      "description" : "a temporary URL linking to the version of the schema used during the ICAR pilot.",
       "type" : "string"
     },
     "scores" : {

--- a/VerbalReasoning/VerbalReasoningJSONSchema.json
+++ b/VerbalReasoning/VerbalReasoningJSONSchema.json
@@ -204,8 +204,12 @@
       "description" : "An identifier that can be used either by the developer or researcher for custom mapping.",
       "type" : "string"
     },
-    "schemaIdentifierPath" : {
+    "jsonSchema" : {
       "description" : "URL linking to the version of the schema against which these data should validate.",
+      "type" : "string"
+    },
+    "$schema" : {
+      "description" : "a temporary URL linking to the version of the schema used during the ICAR pilot.",
       "type" : "string"
     },
     "scores" : {

--- a/VerbalReasoning/VerbalReasoningJSONSchema.json
+++ b/VerbalReasoning/VerbalReasoningJSONSchema.json
@@ -204,11 +204,12 @@
       "description" : "An identifier that can be used either by the developer or researcher for custom mapping.",
       "type" : "string"
     },
+    "schemaIdentifierPath" : {
+      "description" : "URL linking to the version of the schema against which these data should validate.",
+      "type" : "string"
+    },
     "scores" : {
-      "items" : {
-        "$ref" : "#/definitions/MSSRawScoreResult"
-      },
-      "type" : "array"
+      "$ref" : "#/definitions/MSSRawScoreResult"
     },
     "startDate" : {
       "format" : "date-time",


### PR DESCRIPTION
The data failed to validate in Sage's system. Two types of changes are necessary - one is the format for the `scores` object (which does not require rebuilding the app) and the other is renaming the field that links to the schema. I suggest `schemaIdentifierPath` but if you have other suggestions, please make them and I will change the schema.